### PR TITLE
Revert "feat: support selecting outputs with flake attribute installa…

### DIFF
--- a/crates/runix/src/url_parser.rs
+++ b/crates/runix/src/url_parser.rs
@@ -241,23 +241,12 @@ where
 }
 
 /// The possible flake output types
-#[derive(Debug, Deserialize, Clone, PartialEq, Eq, Default)]
+#[derive(Debug, Deserialize, Clone)]
 #[serde(rename_all = "lowercase")]
 pub enum InstallableOutputs {
-    #[default]
-    Default,
     All,
+    Default,
     Selected(Vec<String>),
-}
-
-impl InstallableOutputs {
-    pub fn as_url_suffix(&self) -> String {
-        match self {
-            InstallableOutputs::Default => String::new(),
-            InstallableOutputs::All => "^*".to_string(),
-            InstallableOutputs::Selected(ref outputs) => format!("^{}", outputs.join(",")),
-        }
-    }
 }
 
 /// A flake reference that has been parsed by Nix


### PR DESCRIPTION
…bles (#46)"

This reverts commit d1ba2e30123f8cc340f22284df0c0c54dd2dd2b1.

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [ ] I have read the [Code of Conduct](https://github.com/danopstech/.github/blob/main/CODE_OF_CONDUCT.md)
- [ ] I have updated the documentation accordingly.
- [ ] All commits are GPG signed
